### PR TITLE
Image editor fixes

### DIFF
--- a/components/Observation/Image/Editor.vue
+++ b/components/Observation/Image/Editor.vue
@@ -329,7 +329,6 @@
     canvasRect,
     createImageFile,
     cursor,
-    destroyEditor,
     resetTextDraft,
     fontSizes,
     hasPendingChanges,
@@ -355,6 +354,7 @@
     redoDisabled,
     canvasBackgroundPosition,
     canvasBackgroundSize,
+    removeEventListeners,
   } = useImageEditor(
     props.observation.id,
     props.project.id,
@@ -383,13 +383,12 @@
 
 
   onMounted(() => {
-    destroyEditor();
     reset();
   });
 
   onUnmounted(() => {
-    destroyEditor();
-  })
+    removeEventListeners();
+  });
   
 
 </script>

--- a/components/Observation/Image/Editor.vue
+++ b/components/Observation/Image/Editor.vue
@@ -86,111 +86,108 @@
             size="xs"
           >Overwrite image</UButton>
 
-          <!-- Buttons: Undo/redo buttons -->
-          <UButtonGroup>
-            <UButton @click="undo" :disabled="undoDisabled" color="blue" variant="outline" icon="i-heroicons-arrow-uturn-left"></Ubutton>
-            <UButton @click="redo" :disabled="redoDisabled" color="blue" variant="outline" icon="i-heroicons-arrow-uturn-right"></Ubutton>
-          </UButtonGroup>
-
-          <!-- Buttons: all actions -->
-          <UButtonGroup size="sm" orientation="horizontal">
-            <UButton
-              v-for="[actionMode, { icon, onActionPicked }] in actionButtons"
-              :icon="icon"
-              color="blue"
-              :variant="modeActive(actionMode as unknown as EditorMode) ? 'solid' : 'outline'"
-              @click="() => { setMode(actionMode as unknown as EditorMode); onActionPicked() }"
-              :disabled="modeActive(EditorMode.DISABLED)"
-            />
-          </UButtonGroup>
-
-          <!-- Button group: zoom -->
-          <UButtonGroup size="sm" orientation="horizontal">
-            <UButton
-              color="blue"
-              variant="outline"
-              icon="i-heroicons-magnifying-glass-minus"
-              :disabled="modeActive(EditorMode.DISABLED)"
-              @click="() => addToZoom(-ZOOM_STEP)"
-            ></UButton>
-            <UButton
-              color="blue"
-              variant="outline"
-              icon="i-mdi-restore"
-              :disabled="modeActive(EditorMode.DISABLED)"
-              @click="() => resetZoom()"
-            ></UButton>
-            <UButton
-              color="blue"
-              variant="outline"
-              icon="i-heroicons-magnifying-glass-plus"
-              :disabled="modeActive(EditorMode.DISABLED)"
-              @click="() => addToZoom(ZOOM_STEP)"
-            ></UButton>
-          </UButtonGroup>
         </div>
       </div>
     </template>
-    <div
-      class="w-full relative"
-      v-if="modeActive(EditorMode.LINE) || modeActive(EditorMode.RECT) || modeActive(EditorMode.TEXT)"
-    >
+    <div class="w-full overflow-visible relative" ref="canvasContainer">
+      <div
+        class="w-full sticky top-0 flex justify-between"
+        v-if="!modeActive(EditorMode.DISABLED)"
+      >
 
-      <div class="mb-4 absolute px-3 pt-2 pb-2 rounded-md right-3 top-3 z-10 flex justify-end items-end gap-x-3 bg-slate-950 bg-opacity-80">
+        <div class="px-3 w-full h-16 right-3 z-10 flex justify-between items-center gap-x-3 bg-slate-950 bg-opacity-80">
 
-        <!-- EditorMode.LINE: extra tools -->
-        <div class="flex items-center gap-x-3" v-show="modeActive(EditorMode.LINE)">
-          <label class="text-xs">Line width:</label>
-          <USelectMenu
-            :options="lineWidths"
-            v-model="lineWidth"
-            color="gray"
-            variant="outline"
-            size="xs"
-            value-attribute="value"
-            option-attribute="label"
-            class="cursor-pointer pl-3 pr-8 h-8"
-          >
-            <template #label>
-              {{ lineWidth }}px
-            </template>
-          </USelectMenu>
-        </div>
+          <div class="flex items-center gap-x-3">
+            <!-- Button group: TEXT colors -->
+            <div v-if="modeActive(EditorMode.TEXT)">
+              <UButtonGroup
+                size="sm"
+                orientation="horizontal"
+              >
+                <label
+                  class="h-8 cursor-pointer focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 flex-shrink-0 font-medium rounded-s-md gap-x-1.5 px-2.5 py-1.5 shadow-sm disabled:bg-primary-500 dark:disabled:bg-primary-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:focus-visible:outline-primary-400 inline-flex items-center"
+                  :style="{backgroundColor: frontColor, color: 'black'}"
+                >
+                  <UIcon class="-m-1 text-xl" name="i-heroicons-paint-brush" />
+                  <UInput
+                    v-show="false"
+                    type="color"
+                    class="hidden"
+                    :disabled="modeActive(EditorMode.DISABLED)"
+                    v-model="frontColor"
+                  />
+                </label>
+                <label
+                  class="h-8 cursor-pointer focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 flex-shrink-0 font-medium rounded-e-md gap-x-1.5 px-2.5 py-1.5 shadow-sm disabled:bg-primary-500 dark:disabled:bg-primary-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:focus-visible:outline-primary-400 inline-flex items-center"
+                  :style="{backgroundColor: backColor, color: 'white'}"
+                >
+                  <UIcon class="-m-1 text-xl" name="i-heroicons-paint-brush" />
+                  <UInput
+                    v-show="false"
+                    type="color"
+                    class="hidden"
+                    :disabled="modeActive(EditorMode.DISABLED)"
+                    v-model="backColor"
+                  />
+                </label>
+              </UButtonGroup>
+            </div>
 
-        <!-- EditorMode.TEXT: extra tools -->
-        <div class="flex items-center gap-x-3" v-show="modeActive(EditorMode.TEXT)">
+            <!-- Button group: LINE colors -->
+            <div v-if="modeActive(EditorMode.LINE)">
+              <label
+                class="h-8 cursor-pointer focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 flex-shrink-0 font-medium rounded-md gap-x-1.5 px-2.5 py-1.5 shadow-sm disabled:bg-primary-500 dark:disabled:bg-primary-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:focus-visible:outline-primary-400 inline-flex items-center"
+                :style="{backgroundColor: frontColor, color: 'black'}"
+              >
+                <UIcon class="-m-1 text-xl" name="i-heroicons-paint-brush" />
+                <UInput
+                  v-show="false"
+                  type="color"
+                  class="hidden"
+                  :disabled="modeActive(EditorMode.DISABLED)"
+                  v-model="frontColor"
+                />
+              </label>
+            </div>
 
-          <form @submit.prevent="saveTextDraft" class="flex gap-3 items-end">
-              <!-- text draft textarea-->
-              <UTextarea
-                class="ring-inset h-12 dark:ring-inset border-r-0 dark:border-r-0"
-                v-if="writing"
-                type="text"
-                ref="textInput"
-                v-model="textDraft"
-                :disabled="modeActive(EditorMode.DISABLED)"
-                @update="(v: string) => {
-                  setTextDraft(v);
-                  return v;
-                }"
-                placeholder="Enter text"
-              />
+            <!-- Button group: BOX colors -->
+            <div v-if="modeActive(EditorMode.RECT)">
+              <label
+                class="h-8 cursor-pointer focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 flex-shrink-0 font-medium rounded-md gap-x-1.5 px-2.5 py-1.5 shadow-sm disabled:bg-primary-500 dark:disabled:bg-primary-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:focus-visible:outline-primary-400 inline-flex items-center"
+                :style="{backgroundColor: backColor, color: 'white'}"
+              >
+                <UIcon class="-m-1 text-xl" name="i-heroicons-paint-brush" />
+                <UInput
+                  v-show="false"
+                  type="color"
+                  class="hidden"
+                  :disabled="modeActive(EditorMode.DISABLED)"
+                  v-model="backColor"
+                />
+              </label>
+            </div>
 
-              <!-- save text button-->
-              <UButton
-                v-if="writing"
-                color="blue"
-                type="submit"
+            <!-- EditorMode.LINE: extra tools -->
+            <div class="flex items-center gap-x-3" v-show="modeActive(EditorMode.LINE)">
+              <label class="text-xs">Line width:</label>
+              <USelectMenu
+                :options="lineWidths"
+                v-model="lineWidth"
+                color="gray"
                 variant="outline"
-                class="saveText"
-              >Save text</UButton>
-              <!-- discard text button-->
-              <UButton
-                v-if="writing"
-                color="red"
-                variant="outline"
-                @click="resetTextDraft"
-              >Discard</UButton>
+                size="xs"
+                value-attribute="value"
+                option-attribute="label"
+                class="cursor-pointer pl-3 pr-8 h-8"
+              >
+                <template #label>
+                  {{ lineWidth }}px
+                </template>
+              </USelectMenu>
+            </div>
+
+            <!-- EditorMode.TEXT: extra tools -->
+            <div class="flex items-center gap-x-3" v-show="modeActive(EditorMode.TEXT)">
 
               <!-- toggle background transparency -->
               <div class="flex flex-col items-center gap-x-2">
@@ -201,86 +198,100 @@
                 />
               </div>
 
-              <!-- font size select/dropdown component -->
-              <USelect
-                :options="fontSizes"
-                v-model="textSize"
-                size="sm"
-                color="gray"
-                variant="outline"
-                value-attribute="value"
-                option-attribute="label"
-                class="text-xs cursor-pointer pl-2 pr-2 h-8"
-                placeholder=""
-                :ui="{
-                  trailing: {
-                    padding: {
-                      '2xs': 'pe-0',
-                      'xs': 'pe-0',
-                      'sm': 'pe-0',
-                      'md': 'pe-0',
-                      'lg': 'pe-0',
-                      'xl': 'pe-0'
-                    }
-                  },
-                  color: {
-                    white: {
-                      outline: 'shadow-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-white ring-0',
-                    },
-                    gray: {
-                      outline: 'shadow-sm bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white ring-0',
-                    }
-                  },
-                }"
-              >
-                <template #trailing><div class="hidden"></div></template>
-              </USelect>
-          </form>
-        </div>
+              <form v-if="writing" @submit.prevent="saveTextDraft" class="flex gap-3 items-center">
+                  <!-- text draft textarea-->
+                  <UTextarea
+                    class="ring-inset h-12 dark:ring-inset border-r-0 dark:border-r-0"
+                    type="text"
+                    ref="textInput"
+                    v-model="textDraft"
+                    :disabled="modeActive(EditorMode.DISABLED)"
+                    @update="(v: string) => {
+                      setTextDraft(v);
+                      return v;
+                    }"
+                    placeholder="Enter text"
+                  />
 
-        <!-- Button group: colors -->
-        <div>
-          <UButtonGroup
-            size="sm"
-            orientation="horizontal"
-          >
-            <label
-              class="h-8 cursor-pointer focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 flex-shrink-0 font-medium rounded-s-md gap-x-1.5 px-2.5 py-1.5 shadow-sm disabled:bg-primary-500 dark:disabled:bg-primary-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:focus-visible:outline-primary-400 inline-flex items-center"
-              :style="{backgroundColor: frontColor, color: 'black'}"
-            >
-              <UIcon class="-m-1 text-xl" name="i-heroicons-paint-brush" />
-              <UInput
-                v-show="false"
-                type="color"
-                class="hidden"
+                  <!-- save text button-->
+                  <UButton
+                    color="blue"
+                    type="submit"
+                    variant="outline"
+                    class="saveText"
+                  >Save text</UButton>
+                  <!-- discard text button-->
+                  <UButton
+                    color="red"
+                    variant="outline"
+                    @click="resetTextDraft"
+                  >Discard</UButton>
+              </form>
+
+                  <!-- font size input field -->
+                  <div class="flex items-center gap-x-2">
+                    <label class="text-xs">Size:</label>
+                    <UInput
+                      class="max-w-[70px] text-size-input"
+                      :style="{
+                        appearance: 'textfield',
+                      }"
+                      type="number"
+                      id="text-size-input"
+                      :model-value="textSize"
+                      @update:model-value="setTextSize"
+                      step="1"
+                      variant="outline"
+                    />
+                  </div>
+            </div>
+          </div>
+          <div class="flex gap-x-3">
+            <!-- Buttons: Undo/redo buttons -->
+            <UButtonGroup>
+              <UButton @click="undo" :disabled="undoDisabled" color="blue" variant="outline" icon="i-heroicons-arrow-uturn-left"></Ubutton>
+              <UButton @click="redo" :disabled="redoDisabled" color="blue" variant="outline" icon="i-heroicons-arrow-uturn-right"></Ubutton>
+            </UButtonGroup>
+
+            <!-- Buttons: all actions -->
+            <UButtonGroup size="sm" orientation="horizontal">
+              <UButton
+                v-for="[actionMode, { icon, onActionPicked }] in actionButtons"
+                :icon="icon"
+                color="blue"
+                :variant="modeActive(actionMode as unknown as EditorMode) ? 'solid' : 'outline'"
+                @click="() => { setMode(actionMode as unknown as EditorMode); onActionPicked() }"
                 :disabled="modeActive(EditorMode.DISABLED)"
-                v-model="frontColor"
               />
-            </label>
-            <label
-              class="h-8 cursor-pointer focus:outline-none disabled:cursor-not-allowed disabled:opacity-75 flex-shrink-0 font-medium rounded-e-md gap-x-1.5 px-2.5 py-1.5 shadow-sm disabled:bg-primary-500 dark:disabled:bg-primary-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:focus-visible:outline-primary-400 inline-flex items-center"
-              :style="{backgroundColor: backColor, color: 'white'}"
-            >
-              <UIcon class="-m-1 text-xl" name="i-heroicons-paint-brush" />
-              <UInput
-                v-show="false"
-                type="color"
-                class="hidden"
+            </UButtonGroup>
+
+            <!-- Button group: zoom -->
+            <UButtonGroup size="sm" orientation="horizontal">
+              <UButton
+                color="blue"
+                variant="outline"
+                icon="i-heroicons-magnifying-glass-minus"
                 :disabled="modeActive(EditorMode.DISABLED)"
-                v-model="backColor"
-              />
-            </label>
-          </UButtonGroup>
+                @click="() => addToZoom(-ZOOM_STEP)"
+              ></UButton>
+              <UButton
+                color="blue"
+                variant="outline"
+                icon="i-mdi-restore"
+                :disabled="modeActive(EditorMode.DISABLED)"
+                @click="() => resetZoom()"
+              ></UButton>
+              <UButton
+                color="blue"
+                variant="outline"
+                icon="i-heroicons-magnifying-glass-plus"
+                :disabled="modeActive(EditorMode.DISABLED)"
+                @click="() => addToZoom(ZOOM_STEP)"
+              ></UButton>
+            </UButtonGroup>
+          </div>
         </div>
       </div>
-    </div>
-    <div class="w-full overflow-visible relative" ref="canvasContainer">
-      <UBadge class="flex items-center opacity-70 absolute right-3 top-3" color="blue" size="xs" >
-        <div class="flex items-start gap-x-1 pt-1">
-          <UIcon name="i-heroicons-magnifying-glass" />
-          <div class="font-mono">{{  Math.round(zoom * 100)  }}%</div>
-        </div>
-      </UBadge>
       <canvas
         v-show="!isSaving"
         ref="canvas"
@@ -332,35 +343,34 @@
   // initialize image editor!
   const {
     actionButtons,
+    addToZoom,
+    canvasBackgroundPosition,
+    canvasBackgroundSize,
     canvasRect,
     createImageFile,
     cursor,
-    resetTextDraft,
-    fontSizes,
     hasPendingChanges,
     isSaving,
     lineWidth,
     lineWidths,
     modeActive,
+    redo,
+    redoDisabled,
+    removeEventListeners,
     reset,
+    resetTextDraft,
     resetZoom,
     saveTextDraft,
     setMode,
     setTextDraft,
     setTextDraftSolidBg,
+    setTextSize,
     textDraft,
     textDraftSolidBg,
     textSize,
-    writing,
-    zoom,
-    addToZoom,
-    redo,
     undo,
     undoDisabled,
-    redoDisabled,
-    canvasBackgroundPosition,
-    canvasBackgroundSize,
-    removeEventListeners,
+    writing,
   } = useImageEditor(
     props.observation.id,
     props.project.id,
@@ -404,4 +414,9 @@
   .cursor-grab { cursor: grab; }
   .cursor-grabbing { cursor: grabbing; }
   .cursor-crosshair { cursor: crosshair; }
+  .text-size-input::-webkit-outer-spin-button,
+  .text-size-input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
 </style>

--- a/components/Observation/Image/Editor.vue
+++ b/components/Observation/Image/Editor.vue
@@ -42,6 +42,12 @@
                 </div>
                 <div class="flex gap-x-2">
                   <span class="flex gap-x-1">
+                    <UKbd>Esc</UKbd>
+                  </span>:
+                  <span>(Text mode) Discard text</span>
+                </div>
+                <div class="flex gap-x-2">
+                  <span class="flex gap-x-1">
                     <UKbd>Shift</UKbd>+<UKbd>Scroll</UKbd>
                   </span>:
                   <span>Zoom</span>

--- a/composables/useImageEditor.ts
+++ b/composables/useImageEditor.ts
@@ -448,6 +448,8 @@ export function useImageEditor(
           // save text on ctrl+enter
           if (key === 'Enter' && controlKeyDown.value) {
             saveTextDraft();
+          } else if (key === 'Escape') {
+            resetTextDraft();
           }
         },
       }
@@ -765,6 +767,8 @@ export function useImageEditor(
 
       // also call the actions if they want their own shortcut attached
       action.value.mouseEvents?.scroll?.(ev, up);
+    } else if (!controlKeyDown.value && !shiftKeyDown.value) {
+      console.log('scrolling!', ev)
     }
   }
 

--- a/composables/useImageEditor.ts
+++ b/composables/useImageEditor.ts
@@ -5,11 +5,6 @@ const imageChangeId = () => _imageChangeId++;
 const maxZoom = 10;   // 1000%
 const minZoom = 0.1; // 10%
 
-const fontSizes = [12, 14, 18, 24, 30, 38, 45, 52, 64, 76, 88, 96, 118, 142, 188].map((v) => ({
-  value: v,
-  label: `${v}px`,
-}));
-
 const lineWidths = [2, 3, 5, 8, 13, 21].map((v) => ({
   value: v,
   label: `${v}px`,
@@ -64,7 +59,7 @@ export function useImageEditor(
   });
 
   // focus text area after changing settings while writing
-  watch([textSize, frontColor, backColor], () => {
+  watch([frontColor, backColor], () => {
     if (writing.value) {
       focusTextArea();
     }
@@ -355,8 +350,8 @@ export function useImageEditor(
             drawImage();
             drawBoxes();
             drawBox({ x, y, w, h, fillColor: backColor.value, z: zoom.value, id: 0 }); // TODO: move inside drawSquares
-            drawLines();
             drawTexts(zoom.value);
+            drawLines();
           }
         },
       },
@@ -380,7 +375,6 @@ export function useImageEditor(
             writing.value = true;
             textDraft.value = '';
             cursor.value = 'move';
-            textSize.value = square[3] / zoom.value / 2;
 
             if (square[2] < 0) {
               square[0] = beginX.value + square[2];
@@ -396,12 +390,12 @@ export function useImageEditor(
               y: square[3] / zoom.value,
             };
 
+            textSize.value = Math.ceil(10 * square[3] / zoom.value / 2) / 10;
+
             draftTextPosition.value = [
               (square[0] - cameraPosition.value[0]) / zoom.value,
               (square[1] - cameraPosition.value[1]) / zoom.value
             ];
-
-            focusTextArea();
           }
 
           dragging.value = false;
@@ -434,8 +428,8 @@ export function useImageEditor(
             drawImage();
             drawBoxes();
             drawBox({ x, y, w, h, fillColor: backColor.value, z: zoom.value, id: 0 }); // TODO: move inside drawSquares
-            drawLines();
             drawTexts(zoom.value);
+            drawLines();
           }
         },
         rightUp: (ev) => {
@@ -1076,13 +1070,19 @@ export function useImageEditor(
       .sort(([_k1, a], [_k2, b]) => (a?.menuIndex || 0) > (b?.menuIndex || 0) ? 1 : -1);
   });
 
+  function setTextSize (n: number) {
+    if (!n || typeof n !== 'string') return;
+    const parsed = parseFloat(n);
+    if (isNaN(parsed)) return;
+    textSize.value = parsed;
+  }
+
   return {
     actionButtons,
     canvasRect,
     createImageFile,
     cursor,
     removeEventListeners,
-    fontSizes,
     hasPendingChanges,
     isSaving,
     lineWidth,
@@ -1107,5 +1107,6 @@ export function useImageEditor(
     addToZoom,
     canvasBackgroundPosition,
     canvasBackgroundSize,
+    setTextSize,
   };
 }

--- a/composables/useImageEditor.ts
+++ b/composables/useImageEditor.ts
@@ -5,7 +5,7 @@ const imageChangeId = () => _imageChangeId++;
 const maxZoom = 10;   // 1000%
 const minZoom = 0.1; // 10%
 
-const fontSizes = [12, 14, 18, 24, 30, 38, 45, 52, 64, 76, 88, 96].map((v) => ({
+const fontSizes = [12, 14, 18, 24, 30, 38, 45, 52, 64, 76, 88, 96, 118, 142, 188].map((v) => ({
   value: v,
   label: `${v}px`,
 }));
@@ -380,6 +380,7 @@ export function useImageEditor(
             writing.value = true;
             textDraft.value = '';
             cursor.value = 'move';
+            textSize.value = square[3] / zoom.value / 2;
 
             if (square[2] < 0) {
               square[0] = beginX.value + square[2];

--- a/utils/imageEditor.ts
+++ b/utils/imageEditor.ts
@@ -144,8 +144,7 @@ export function mouseRect(
 ): SquareWithZoom {
   const { x, y } = mousePosition(ev, canvas);
 
-  // TODO: support boxes made from other direction
-  // TODO: test if already possible? it seems :S
+  // TODO: support boxes made from other direction here instead of client code
   const square: SquareWithZoom = {
     x: beginX,
     y: beginY,


### PR DESCRIPTION
- Text area focus logic (https://github.com/nikobojs/manuscrape_electron/issues/38)
- Streamline event listener mounted/onmounted logic
- Add escape shortcut to discard a text (https://github.com/nikobojs/manuscrape_electron/issues/41)
- Set text-size the same size as the drawn box (https://github.com/nikobojs/manuscrape_electron/issues/39)
- Hide unused color pencil buttons (https://github.com/nikobojs/manuscrape_electron/issues/28)
- Make toolbar sticky https://github.com/nikobojs/manuscrape_electron/issues/24
- Make text size into number input field
- Fix lines hiding below boxes when moving stuff
- Hide zoom percentage (create an issue if you want it back!)